### PR TITLE
chore(*): change the text in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ yarn add arui-presets-lint --dev
 ----------------------
 
 #### commitlint
-Вы можете унаследовать конфигурацию вашего commitlint от `arui-presets/commitlint`.
+Вы можете унаследовать конфигурацию вашего commitlint от `arui-presets-lint/commitlint`.
 
 
 Файл `commitlint.config.js` вашего проекта:
 ```js
 module.exports = {
-    extends: ['arui-presets/commitlint']
+    extends: ['./node_modules/arui-presets-lint/commitlint']
 };
 ```
 
 
 #### eslint
-Вы можете унаследовать конфигурацию вашего eslint от `arui-presets/eslint`.
+Вы можете унаследовать конфигурацию вашего eslint от `arui-presets-lint/eslint`.
 К сожалению, разработчики eslint [очень нехотят](https://github.com/eslint/eslint/issues/3458) делать полноценную систему для общих конфигураций, так что вам 
 необходимо так же установить `peerDependencies`.
 
@@ -57,18 +57,18 @@ npm install eslint eslint-config-airbnb eslint-plugin-class-methods-use-this-reg
 Файл `.eslintrc.js` вашего проекта:
 ```js
 module.exports = {
-    extends: require.resolve('arui-presets/eslint')
+    extends: require.resolve('arui-presets-lint/eslint')
 };
 ```
 
 #### stylelint
-Вы можете унаследовать конфигурацию вашего stylelint от `arui-presets/stylelint`.
+Вы можете унаследовать конфигурацию вашего stylelint от `arui-presets-lint/stylelint`.
 
 
 Файл `stylelint.config.js` вашего проекта:
 ```js
 module.exports = {
-    extends: 'arui-presets/stylelint'
+    extends: 'arui-presets-lint/stylelint'
 };
 ```
 


### PR DESCRIPTION
1. Поправил текст
2. Поменял путь до настроек commitlint'а на относительный, из-за [требований по именованию модуля](https://github.com/marionebl/commitlint#shared-configuration) содержащего внешний конфиг: <img width="852" alt="img" src="https://user-images.githubusercontent.com/37327825/50314641-adf11280-04c0-11e9-9c67-e0b0c762c786.png"> В противном случае commitlint при резолве будет добавлять префикс к имени подключаемого модуля, что приведёт к `сannot find module`: <img width="693" alt="img2" src="https://user-images.githubusercontent.com/37327825/50314448-f825c400-04bf-11e9-8b11-1eedb635aac1.png">
