### PR TITLE
fix(eslint): disable multiline-comment-style rule

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -43,7 +43,7 @@ module.exports = {
             ignoreStrings: true,
             ignoreTemplateLiterals: true
         }],
-        'multiline-comment-style': ['warn', 'starred-block'],
+        'multiline-comment-style': 'off',
         'no-multiple-empty-lines': ['warn', { max: 1, maxBOF: 0, maxEOF: 1 }],
         'no-negated-condition': 'warn',
         'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],


### PR DESCRIPTION
Предлагаю это правило отключить. Краткая суть правила в текущей реализации: многострочные коменты должны быть в `/**/` и каждая строчка комментария должна начинаться с `*`.
Я не вижу ни одной проблемы, которую это правило решает.
БольшАя часть комментариев - это что-то вида
```
// TODO: fix next line
// doSomethingUnavailable();
// orMaybeSomethingElse();
```
Вроде почти все сейчас пользуются нормальными редакторами и делают подобные коменты выделяя код и нажимая что-то типа ⌘+/. 

И вообще, ни в одном редакторе я не видел кейбиндинга для создания коментов в таком стиле. Своими глазами наблюдал как разработчик руками ставил * на каждой строке чтоб заткнуть линтер.