### PR TITLE
fix(eslint): toggle off indent rule

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -34,7 +34,8 @@ module.exports = {
         'func-names': 'off',
         'function-paren-newline': 'off',
         'implicit-arrow-linebreak': ['warn', 'beside'],
-        indent: ['error', 4, { SwitchCase: 1 }],
+        // breaks indent for generics
+        indent: 'off',
         'jsx-quotes': ['error', 'prefer-single'],
         'max-len': ['error', 120, 4, {
             ignoreUrls: true,


### PR DESCRIPTION
Хочу спросить совета.

Правило indent некорректно работает с generic'ами, это видно по тому, как выравнивает Prettier:
```ts
export const myThunk = (): ThunkAction<
void,
AppState,
{},
ActionTypes
> => (dispatch, getState) => {
```

При отключенном правиле, prettier выравнивает правильно:
```ts
export const myThunk = (): ThunkAction<
    void,
    AppState,
    {},
    ActionTypes
> => (dispatch, getState) => {
```

Что делать я не знаю, есть идеи?