### PR TITLE
Remove jsx-one-expression-per-line

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -114,6 +114,7 @@ module.exports = {
         'react/prefer-stateless-function': 'off',
         'react/require-default-props': 'off',
         'react/sort-comp': 'off',
+        'react/jsx-one-expression-per-line': 'off',
 
         // A11Y
         'jsx-a11y/href-no-hash': 'off',


### PR DESCRIPTION
Линтер на код:
`<h1>Hello, { name }</h1>`
Выдает ошибку, предлагая отформатировать так:
```
<h1>
    Hello,
    { name }
</h1>
```
это не удобно 