### PR TITLE
fix/deps-conventional. move conventional devDeps -> Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
+    "conventional-changelog-cli": "1.3.21",
+    "conventional-github-releaser": "2.0.2",
     "arui-cssvars": "1.1.5",
     "babel-eslint": "^10.0.3",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
@@ -23,8 +25,6 @@
     "eslint-plugin-sort-class-members": ">= 1.3.0"
   },
   "devDependencies": {
-    "conventional-changelog-cli": "1.3.21",
-    "conventional-github-releaser": "2.0.2",
     "eslint": "6.6.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-chai-friendly": "^0.4.1",


### PR DESCRIPTION
Переместил:
- "conventional-changelog-cli";
-"conventional-github-releaser";

из devDeps -> Deps т.к они необходимы в проектах которые используют arui-presets-lint, но сейчас устанавливаются явно.