### PR TITLE
docs(readme): commitlint in husky-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ npm info "arui-presets-lint@latest" peerDependencies
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint-staged"
+      "pre-commit": "yarn lint-staged",
+      "commit-msg": "commitlint -e"
     }
   }
 }
@@ -119,7 +120,8 @@ npm info "arui-presets-lint@latest" peerDependencies
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint-staged"
+      "pre-commit": "yarn lint-staged",
+      "commit-msg": "commitlint -e"
     }
   },
   "prettier": "arui-presets-lint/prettier",


### PR DESCRIPTION
Кажется, что в ридми этого не хватает. Видел команды, которые забывают про этот пункт, при этом пребывают в полной уверенности, что линтер на коммиты работает.