### PR TITLE
fix(eslint): resolve conflict with prettier

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -37,7 +37,7 @@ module.exports = {
         'react/jsx-indent': ['warn', 4],
         'react/jsx-indent-props': ['warn', 4],
         'react/jsx-curly-spacing': ['warn', 'never'],
-        quotes: ['warn', 'single'],
+        quotes: ['warn', 'single', { avoidEscape: true }],
         'comma-dangle': ['warn', 'always-multiline'],
         'comma-spacing': ['warn', { before: false, after: true }],
         'comma-style': ['warn', 'last'],


### PR DESCRIPTION
При наличии строки вида `'don\'t touch me'` преттир конвертит её в `"don't touch me"`, что не нравится линтеру.

Альтернатива `avoidEscape` —  `allowTemplateLiterals`, но тогда шаблонные строки будут появляться даже там, где не надо.

В своих командах поправил в локальном eslintrc, но хотелось бы поскорее выпустить патчевую версию с этим фиксом.