### PR TITLE
fix(eslint): allow to import devDependencies in storybook and test files

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -112,6 +112,10 @@ module.exports = {
         ],
 
         // Imports, file extensions
+        'import/no-extraneous-dependencies': [
+            'error',
+            { devDependencies: ['**/*.{stories,test,tests,spec}.{js,jsx,ts,tsx}'] },
+        ],
         'import/prefer-default-export': 'off',
         'import/no-unresolved': 'off',
         'import/extensions': 'off',


### PR DESCRIPTION
Исправляем ошибки импорта dev зависимостей в файлах, используемых для разработки. Фиксим #36 