### PR TITLE
update lib version to skip warnings when linter rule is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.3.4",
-        "arui-cssvars": "1.1.5",
+        "arui-cssvars": "1.1.6",
         "babel-eslint": "^10.0.3",
         "case-sensitive-paths-webpack-plugin": "2.3.0",
         "command-line-args": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.3.4",
-        "arui-cssvars": "1.1.6",
+        "arui-cssvars": "1.1.7",
         "babel-eslint": "^10.0.3",
         "case-sensitive-paths-webpack-plugin": "2.3.0",
         "command-line-args": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,10 +723,10 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-arui-cssvars@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/arui-cssvars/-/arui-cssvars-1.1.5.tgz#45fa12be75a09e8e875a763c94b40a4a518183e7"
-  integrity sha512-IyNkZX5B8kA5urVGUJJmDlbGynB3auoTOXQwBLO1WdjXmFVsRbLQ5bvcAIt3+nOR3aTOVZV8BFDK3JTax1HXHA==
+arui-cssvars@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/arui-cssvars/-/arui-cssvars-1.1.6.tgz#73f11709dd6ec593624611846270feed2cea0983"
+  integrity sha512-D0BrwCuKuqCTaShPG+P+bAuU5cHEGJDJkGZgNp2nDDiuTgwPZJ1XEHsKgRTRCXXo1Me9Q9ZtTUZluALaMagaRQ==
 
 assign-symbols@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,10 +723,10 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-arui-cssvars@1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/arui-cssvars/-/arui-cssvars-1.1.6.tgz#73f11709dd6ec593624611846270feed2cea0983"
-  integrity sha512-D0BrwCuKuqCTaShPG+P+bAuU5cHEGJDJkGZgNp2nDDiuTgwPZJ1XEHsKgRTRCXXo1Me9Q9ZtTUZluALaMagaRQ==
+arui-cssvars@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/arui-cssvars/-/arui-cssvars-1.1.7.tgz#c132b407af688e100b537e4e9cf068729510df78"
+  integrity sha512-7WRFTgdYU1BC3oVM0TG1OLg0lyHyriukMqOtWlSX25wLTRJPX9p+ayW0JKbtb7Xw0elOtnYlLtMq9tPp83j/qw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Omit warnings from [this issue](https://github.com/alfa-laboratory/arui-presets-lint/issues/24).
Disable rule on your project to skip warning messages:
```
  "stylelint": {
    "extends": "arui-presets-lint/stylelint",
    "rules": {
      "arui-cssvars/use-variables": false
    }
  },
```
-------
Убраны предупреждения, описанные [в этой проблеме](https://github.com/alfa-laboratory/arui-presets-lint/issues/24).
Отключите правило в проекте, чтобы скрыть предупреждения.