### PR TITLE
improvement(eslint): add jsx-quotes

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -22,6 +22,7 @@ module.exports = {
     },
     rules: {
         quotes: ['warn', 'single', { avoidEscape: true }],
+        'jsx-quotes': ['error', 'prefer-single'],
         'comma-dangle': ['warn', 'always-multiline'],
         'comma-spacing': ['warn', { before: false, after: true }],
         'comma-style': ['warn', 'last'],
@@ -109,8 +110,8 @@ module.exports = {
         'import/no-unresolved': 'off',
         'import/extensions': 'off',
         'import/no-useless-path-segments': ['error', {
-            'noUselessIndex': true
-        }]
+            noUselessIndex: true,
+        }],
     },
     overrides: [
         {

--- a/test/css-input.css
+++ b/test/css-input.css
@@ -1,3 +1,5 @@
+@import '...';
+
 :root {
     --red: #f00;
 }

--- a/test/js-input.jsx
+++ b/test/js-input.jsx
@@ -43,4 +43,4 @@ function definedAfterUsage() {
     console.log('Because it is normal!');
 }
 
-export const element = <div style={ { color: 'black' } } />;
+export const element = <div style={ { color: 'black' } } prop='prop' />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,7 +3682,7 @@ meow@5.0.0, meow@^5.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
-    yargs-parser "^10.0.0"
+    yargs-parser "^13.1.2"
 
 meow@^3.3.0:
   version "3.7.0"


### PR DESCRIPTION
Добавил правило `'jsx-quotes': ['error', 'prefer-single']`. Без него в `jsx` линтер хочет двойные кавычки.
Вручную заменил версию пакета **yargs-parser** в yarn.lock, потому что иначе не получалось закоммитить из-за npm audit. Некоторые команды из packages.json позапускал, линтинг работает.