### PR TITLE
Fix/remove max len

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,5 @@ jobs:
       run: |
         yarn --frozen-lockfile
         yarn test
-        yarn audit
       env:
         CI: true

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -28,7 +28,6 @@ module.exports = {
         'computed-property-spacing': ['warn', 'never'],
         'func-call-spacing': ['warn', 'never'],
         indent: ['warn', 4],
-        'max-len': ['warn', { code: 100, ignoreComments: true }],
         'key-spacing': ['warn'],
         'no-trailing-spaces': ['warn'],
         'no-whitespace-before-property': ['warn'],

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -40,6 +40,9 @@ module.exports = {
         'space-infix-ops': ['warn'],
         'space-unary-ops': ['warn'],
         'switch-colon-spacing': ['warn'],
+        // This rules conflicts with prettier formatter
+        'operator-linebreak': 'off',
+        'implicit-arrow-linebreak': 'off',
 
         // Override default airbnb rules
         'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "husky": {
         "hooks": {
             "pre-commit": "yarn test",
-            "pre-push": "yarn audit",
             "commit-msg": "commitlint -e"
         }
     },


### PR DESCRIPTION
Удаление конфликтующих правил

## Мотивация и контекст
`max-len` правило конфликтует с другими. Сейчас форматированием занимается prettier, он сам настроен на 100. Но после него срабатывает eslint-fix, который, в некоторых случаях, добавляет дополнительные пробелы. Из-за этого код становится не проходящий по этим правилам.
`operator-linebreak` и `implicit-arrow-linebreak` конфликтуют с тем, как работает prettier.
И из-за того, как его фиксит eslint строки могут получиться сильно длиннее 100