### PR TITLE
fix(eslint): replace deprecated label-has-for

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -83,7 +83,7 @@ module.exports = {
 
         // A11Y
         'jsx-a11y/anchor-is-valid': ['warn', { aspects: ['invalidHref'] }],
-        'jsx-a11y/label-has-for': ['error', { components: ['label'], allowChildren: true }],
+        'jsx-a11y/label-has-associated-control': ['error', { labelComponents: ['label'], assert: 'either' }],
 
         // typescript
         '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
Fixes #56 


## Мотивация и контекст
Суть проблемы описана в issue.
