### PR TITLE
feat(readme): update prettier-eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ coverage
 ```json
 {
     "lint-staged": {
-        "src/**/*.{js,jsx,ts,tsx,json}": ["prettier-eslint --write", "git add", "eslint"],
+        "{src,config}/**/*.{js,jsx,ts,tsx}": ["prettier-eslint --write", "git add", "eslint"],
         "*.css": ["prettier-eslint --write", "git add", "stylelint"]
     },
     "husky": {
@@ -108,7 +108,7 @@ coverage
         "format": "prettier-eslint --write $INIT_CWD/{config,src}/**/*.{ts,tsx,js,jsx,css}"
     },
     "lint-staged": {
-        "src/**/*.{js,jsx,ts,tsx,json}": ["prettier-eslint --write", "git add", "eslint"],
+        "{src,config}/**/*.{js,jsx,ts,tsx}": ["prettier-eslint --write", "git add", "eslint"],
         "*.css": ["prettier-eslint --write", "git add", "stylelint"]
     },
     "husky": {

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm info "arui-presets-lint@latest" peerDependencies
         "lint:css": "stylelint ./src/**/*.css",
         "lint:scripts": "eslint \"**/*.{js,jsx,ts,tsx}\" --ext .js,.jsx,.ts,.tsx",
         "lint": "yarn lint:css && yarn lint:scripts",
-        "format": "prettier-eslint --write \"./{config,src}/**/*.{ts,tsx,js,jsx,json,css}\""
+        "format": "prettier-eslint --write $INIT_CWD/{config,src}/**/*.{ts,tsx,js,jsx,css}"
     }
 }
 ```
@@ -105,7 +105,7 @@ coverage
         "lint:css": "stylelint ./src/**/*.css",
         "lint:scripts": "eslint \"**/*.{js,jsx,ts,tsx}\" --ext .js,.jsx,.ts,.tsx",
         "lint": "yarn lint:css && yarn lint:scripts",
-        "format": "prettier-eslint --write \"./{config,src}/**/*.{ts,tsx,js,jsx,json,css}\""
+        "format": "prettier-eslint --write $INIT_CWD/{config,src}/**/*.{ts,tsx,js,jsx,css}"
     },
     "lint-staged": {
         "src/**/*.{js,jsx,ts,tsx,json}": ["prettier-eslint --write", "git add", "eslint"],

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,10 +1,6 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    extends: [
-        'airbnb-typescript',
-        'airbnb/hooks',
-        'plugin:@typescript-eslint/recommended',
-    ],
+    extends: ['airbnb-typescript', 'airbnb/hooks', 'plugin:@typescript-eslint/recommended'],
     parserOptions: {
         project: './tsconfig.json',
         ecmaVersion: 2018,
@@ -88,7 +84,10 @@ module.exports = {
 
         // A11Y
         'jsx-a11y/anchor-is-valid': ['warn', { aspects: ['invalidHref'] }],
-        'jsx-a11y/label-has-associated-control': ['error', { labelComponents: ['label'], assert: 'either' }],
+        'jsx-a11y/label-has-associated-control': [
+            'error',
+            { labelComponents: ['label'], assert: 'either' },
+        ],
 
         // typescript
         '@typescript-eslint/indent': ['warn', 4, { SwitchCase: 1 }],
@@ -118,9 +117,12 @@ module.exports = {
         'import/prefer-default-export': 'off',
         'import/no-unresolved': 'off',
         'import/extensions': 'off',
-        'import/no-useless-path-segments': ['error', {
-            noUselessIndex: true,
-        }],
+        'import/no-useless-path-segments': [
+            'error',
+            {
+                noUselessIndex: true,
+            },
+        ],
     },
     overrides: [
         {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "test": "yarn test:eslint && yarn test:stylelint",
         "test:eslint": "eslint \"./test/**/*.{ts,tsx,js,jsx}\"",
         "test:stylelint": "node ./test/stylelint-test.js",
-        "format": "prettier-eslint --write \"./{eslint,stylelint,test,commitlint}/**/*.{ts,tsx,js,jsx,css}\""
+        "format": "prettier-eslint --write $INIT_CWD/{eslint,stylelint,test,commitlint}/**/*.{ts,tsx,js,jsx,css}"
     },
     "lint-staged": {
         "**/*.{js,jsx,ts,tsx,css}": [


### PR DESCRIPTION
На данный момент при запуске команды **format** мы получаем ошибку:

```
prettier-eslint [ERROR]: There was trouble creating the ESLint CLIEngine.
prettier-eslint-cli [ERROR]: There was an error formatting "src/index.ts": 
    AssertionError [ERR_ASSERTION]: 'basePath' should be an absolute path.
```

Данная проблема описана тут:
https://github.com/prettier/prettier-eslint-cli/issues/208

Решение:
```
        "format": "prettier-eslint --write \"./{config,src}/**/*.{ts,tsx,js,jsx,json,css}\""
```
заменяем на:
```
        "format": "prettier-eslint --write \"$PWD/{config,src}/**/*.{ts,tsx,js,jsx,json,css}\""
```
