### PR TITLE
feat(eslint): override rule for JSX-quotes

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -30,6 +30,7 @@ module.exports = {
     },
     rules: {
         quotes: ['warn', 'single', { avoidEscape: true }],
+        'jsx-quotes': ['warn', 'prefer-single'],
         'comma-dangle': ['warn', 'always-multiline'],
         'comma-spacing': ['warn', { before: false, after: true }],
         'comma-style': ['warn', 'last'],


### PR DESCRIPTION
<!--- Название для изменений -->
Переопределение правила `jsx-quotes`
## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
В базовом конфиге airbnb включены двойные кавычки для JSX атрибутов [ссылка](https://github.com/airbnb/javascript/blob/c48a060aff9a4ba66003b18e6a27fd899581f95a/packages/eslint-config-airbnb/rules/react.js#L26). Данные изменения устанавливают одинарные кавычки для JSX атрибутов, по аналогии со строками 
<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
