### PR TITLE
feat(eslint): add padding-line-between-statements rule

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -39,6 +39,12 @@ module.exports = {
         'key-spacing': ['warn'],
         'no-trailing-spaces': ['warn'],
         'no-whitespace-before-property': ['warn'],
+        'padding-line-between-statements': [
+            'warn',
+            { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+            { blankLine: 'always', prev: '*', next: 'return' },
+            { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] },
+        ],
         'quote-props': ['warn', 'as-needed'],
         semi: ['warn'],
         'semi-spacing': ['warn'],

--- a/test/ts-input.tsx
+++ b/test/ts-input.tsx
@@ -14,6 +14,7 @@ function addTypedObjectToCache<Type, Cache extends CacheHostGeneric<Type>>(
     cache: Cache,
 ): Cache {
     cache.save(obj);
+
     return cache;
 }
 


### PR DESCRIPTION
<!--- Название для изменений -->
Добавление eslint правила "padding-line-between-statements"
## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
Помогает сделать код читабельнее добавляя пустые строки после const, var, let и перед return.

Решение не идеальное, т.к. на данный момент настроено не супер strict, а вспомогательно, чтобы совсем плохо не писали. Но помогает держать проекты в более адекватном состоянии. На его основе можно построить более комплексное решение, добавив пустые строки хоть перед каждым if. 

Пример до-после:
![2020-11-03 at 01 20](https://user-images.githubusercontent.com/22435711/97925677-df9cbb00-1d72-11eb-9d91-d1df9d39faef.jpeg)
<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
