### PR TITLE
fix(eslint): disable conflict rules

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -57,17 +57,10 @@ module.exports = {
         'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
         'no-negated-condition': 'warn',
         'default-case': 'off',
-        'no-use-before-define': [
-            'error',
-            {
-                functions: false,
-                classes: true,
-                variables: true,
-            },
-        ],
+        'no-use-before-define': 'off',
 
         // rules should be transformed to errors
-        'no-shadow': 'warn',
+        'no-shadow': 'off',
 
         // code smell detection
         complexity: ['warn', 20],
@@ -114,6 +107,7 @@ module.exports = {
             'error',
             { functions: false, classes: true, variables: true },
         ],
+        '@typescript-eslint/no-shadow': ['warn'],
 
         // Imports, file extensions
         'import/no-extraneous-dependencies': [


### PR DESCRIPTION
Обновил в проекте до последней версии, и всплыли странные конфликты:

1. eslint во всех файлах тыкает на импорт реакта, и жалуется, что `'React' was used before it was defined`
2. Также линтеру не дают покоя типы, и каждый помечается ошибкой: `is already declared in the upper scope.`
Погуглил, оказалось, что конфликтуют между собой правила `no-use-before-define` и `no-shadow` с правилами из набора `@typescript-eslint`.

Заменил `no-shadow` на `@typescript-eslint/no-shadow`, `no-use-before-define` на `@typescript-eslint/no-use-before-define` — конфликты пропали.

Ишью: #114 