### PR TITLE
fix(eslint): add ignore typescript generic type params

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -98,7 +98,11 @@ module.exports = {
         ],
 
         // typescript
-        '@typescript-eslint/indent': ['warn', 4, { SwitchCase: 1 }],
+        '@typescript-eslint/indent': ['warn', 4, {
+            SwitchCase: 1,
+            ignoredNodes: ['TSTypeParameterInstantiation'],
+        },
+        ],
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/array-type': [

--- a/test/ts-input.tsx
+++ b/test/ts-input.tsx
@@ -32,3 +32,10 @@ class SuperCache<T> implements CacheHostGeneric<T> {
 const cache = new SuperCache<number>();
 
 addTypedObjectToCache(123, cache);
+
+type PickedCacheHost = Required<
+    Pick<
+        CacheHostGeneric<string>,
+        'save'
+    >
+>;


### PR DESCRIPTION
Игнорировние indent для параметров typescript

## Мотивация и контекст
Форматировние неправильно работает для multi-line параметров - получается каша.
Обновление либ пока не решает проблему.

https://github.com/alfa-laboratory/arui-presets-lint/issues/119