### PR TITLE
feat(eslint): forbid to use it.only and describe.only

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -71,6 +71,19 @@ module.exports = {
         // code smell detection
         complexity: ['warn', 20],
         'max-nested-callbacks': 'warn',
+        'no-restricted-properties': [
+            'error',
+            {
+                object: 'it',
+                property: 'only',
+                message: "Don't you forget to remove 'only' from this test?",
+            },
+            {
+                object: 'describe',
+                property: 'only',
+                message: "Don't you forget to remove 'only' from this test?",
+            },
+        ],
 
         // React
         'react/jsx-indent': ['warn', 4],

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -83,6 +83,16 @@ module.exports = {
                 property: 'only',
                 message: "Don't you forget to remove 'only' from this test?",
             },
+            {
+                object: 'context',
+                property: 'only',
+                message: "Don't you forget to remove 'only' from this test?",
+            },
+            {
+                object: 'test',
+                property: 'only',
+                message: "Don't you forget to remove 'only' from this test?",
+            },
         ],
 
         // React

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -76,22 +76,22 @@ module.exports = {
             {
                 object: 'it',
                 property: 'only',
-                message: "Don't you forget to remove 'only' from this test?",
+                message: "Did you forget to remove 'only' from this test?",
             },
             {
                 object: 'describe',
                 property: 'only',
-                message: "Don't you forget to remove 'only' from this test?",
+                message: "Did you forget to remove 'only' from this test?",
             },
             {
                 object: 'context',
                 property: 'only',
-                message: "Don't you forget to remove 'only' from this test?",
+                message: "Did you forget to remove 'only' from this test?",
             },
             {
                 object: 'test',
                 property: 'only',
-                message: "Don't you forget to remove 'only' from this test?",
+                message: "Did you forget to remove 'only' from this test?",
             },
         ],
 

--- a/test/js-input.jsx
+++ b/test/js-input.jsx
@@ -42,3 +42,8 @@ function definedAfterUsage() {
 }
 
 export const element = <div style={ { color: 'black' } } />;
+
+const it = () => {};
+
+// eslint-disable-next-line no-restricted-properties
+it.only('this is a test');


### PR DESCRIPTION
Запрещаем использовать it.only и describe.only

## Мотивация и контекст
`it.only` и `describe.only` почти никогда не являются тем кодом, который вы хотели бы закомитить. В процессе разработки им удобно пользоваться для запуска только конкретных тестов в watch режиме например, но дальше очень легко забыть то, что ты их написал и успешно закомитить такой код. Запуск тестов на прекомит при этом успешно пройдет, тесты не упадут. Узнать про это можно только если внимательно смотреть за выполнением тестов, либо если настроен лимит на coverage, либо на ревью. Никакой их этих вариантов не является приятным.