### PR TITLE
chore(github): up nodejs versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Поднимаем используемые в пайплайне версии ноды

## Мотивация и контекст
Многие пакеты перестали поддерживать 10 ноду, сборка на ней будет падать.