### PR TITLE
feat(eslint): add pascal case for enums

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -141,6 +141,10 @@ module.exports = {
         '@typescript-eslint/type-annotation-spacing': 'error',
         '@typescript-eslint/member-delimiter-style': 'error',
         '@typescript-eslint/consistent-type-assertions': 'error',
+        '@typescript-eslint/naming-convention': [
+            'error',
+            { selector: 'enumMember', format: ['PascalCase'] },
+        ],
         '@typescript-eslint/no-array-constructor': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
         '@typescript-eslint/no-shadow': 'warn',


### PR DESCRIPTION
Добавление правила в eslint для именования enums

## Мотивация и контекст
У нас на проектах кто-то использует UPPER_CASE, кто-то camelCase, кто-то PascalCase для енамом, предлагается следовать стандартной документации typescript и именовать enums в PascalCase

Данным правилом мы пытаемся стандартизировать написание свойств в енамах, вместо такого
```
enum MyCase {
    oneCase = 'rr',
    TWO_CASE = 'fdfd',
    third_case = 'ff',
    default = 'tttt'
}
```

Предлагаем писать в таком стиле
```
enum MyCase {
    OneCase = 'rr',
    TwoCase = 'fdfd',
    ThirdCase = 'ff',
    Default = 'tttt'
}
```

но данное правило пропускает такое написание
```
enum MyTest {
  UP = 'up',
  DOWN = 'down'
}
```
